### PR TITLE
Add support for Hob type.

### DIFF
--- a/addons/binding/org.openhab.binding.homeconnect/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.homeconnect/ESH-INF/thing/thing-types.xml
@@ -184,6 +184,29 @@
 		</config-description>
 	</thing-type>
 
+	<!-- Hob -->
+	<thing-type id="hob">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="api_bridge" />
+		</supported-bridge-type-refs>
+		<label>Hob</label>
+		<description>Home Connect connected hob (e.g. Bosch or Siemens).</description>
+		<channels>
+			<channel id="selected_program_state" typeId="selected_program_state" />
+			<channel id="active_program_state" typeId="active_program_state" />
+			<channel id="power_state" typeId="power_state" />
+			<channel id="remote_control_active_state" typeId="remote_control_active_state" />
+			<channel id="local_control_active_state" typeId="local_control_active_state" />
+			<channel id="operation_state" typeId="operation_state" />
+		</channels>
+		<config-description>
+			<parameter name="haId" type="text" required="true">
+				<label>haId</label>
+				<description>Unique identifier representing a specific home appliance.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<!-- Channel types -->
 	<channel-type id="power_state">
 		<item-type>Switch</item-type>
@@ -218,6 +241,12 @@
 			change (only disabling), or manually by the user changing the flag locally on the home appliance, or automatically
 			after a certain duration - usually 24 hours.
 		</description>
+		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="local_control_active_state">
+		<item-type>Switch</item-type>
+		<label>Local Control Activation State</label>
+		<description>This status indicates whether the allowance for local controlling is enabled.</description>
 		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="remote_control_active_state">

--- a/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
+++ b/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
@@ -36,6 +36,7 @@ public class HomeConnectBindingConstants {
     public static final ThingTypeUID THING_TYPE_FRIDGE_FREEZER = new ThingTypeUID(BINDING_ID, "fridgefreezer");
     public static final ThingTypeUID THING_TYPE_DRYER = new ThingTypeUID(BINDING_ID, "dryer");
     public static final ThingTypeUID THING_TYPE_COFFEE_MAKER = new ThingTypeUID(BINDING_ID, "coffeemaker");
+    public static final ThingTypeUID THING_TYPE_HOB = new ThingTypeUID(BINDING_ID, "hob");
 
     // SSE Event types
     public static final String EVENT_ELAPSED_PROGRAM_TIME = "BSH.Common.Option.ElapsedProgramTime";
@@ -49,6 +50,7 @@ public class HomeConnectBindingConstants {
     public static final String EVENT_SELECTED_PROGRAM = "BSH.Common.Root.SelectedProgram";
     public static final String EVENT_REMOTE_CONTROL_START_ALLOWED = "BSH.Common.Status.RemoteControlStartAllowed";
     public static final String EVENT_REMOTE_CONTROL_ACTIVE = "BSH.Common.Status.RemoteControlActive";
+    public static final String EVENT_LOCAL_CONTROL_ACTIVE = "BSH.Common.Status.LocalControlActive";
     public static final String EVENT_REMAINING_PROGRAM_TIME = "BSH.Common.Option.RemainingProgramTime";
     public static final String EVENT_PROGRAM_PROGRESS = "BSH.Common.Option.ProgramProgress";
     public static final String EVENT_SETPOINT_TEMPERATURE = "Cooking.Oven.Option.SetpointTemperature";
@@ -60,6 +62,11 @@ public class HomeConnectBindingConstants {
     public static final String EVENT_FREEZER_SUPER_MODE = "Refrigeration.FridgeFreezer.Setting.SuperModeFreezer";
     public static final String EVENT_FRIDGE_SUPER_MODE = "Refrigeration.FridgeFreezer.Setting.SuperModeRefrigerator";
     public static final String EVENT_DRYER_DRYING_TARGET = "LaundryCare.Dryer.Option.DryingTarget";
+    public static final String EVENT_PROGRAM_FINISHED = "BSH.Common.Event.ProgramFinished";
+    public static final String EVENT_ALARM_ELAPSED = "BSH.Common.Event.AlarmClockElapsed";
+    public static final String EVENT_PREHEAT_FINISHED = "Cooking.Oven.Event.PreheatFinished";
+    
+
 
     // Channel IDs
     public static final String CHANNEL_DOOR_STATE = "door_state";
@@ -70,6 +77,7 @@ public class HomeConnectBindingConstants {
     public static final String CHANNEL_SELECTED_PROGRAM_STATE = "selected_program_state";
     public static final String CHANNEL_REMOTE_START_ALLOWANCE_STATE = "remote_start_allowance_state";
     public static final String CHANNEL_REMOTE_CONTROL_ACTIVE_STATE = "remote_control_active_state";
+    public static final String CHANNEL_LOCAL_CONTROL_ACTIVE_STATE = "local_control_active_state";
     public static final String CHANNEL_REMAINING_PROGRAM_TIME_STATE = "remaining_program_time_state";
     public static final String CHANNEL_PROGRAM_PROGRESS_STATE = "program_progress_state";
     public static final String CHANNEL_OVEN_CURRENT_CAVITY_TEMPERATURE = "oven_current_cavity_temperature";
@@ -86,12 +94,13 @@ public class HomeConnectBindingConstants {
     // List of all supported devices
     public static final Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = Stream
             .of(THING_TYPE_API_BRIDGE, THING_TYPE_DISHWASHER, THING_TYPE_OVEN, THING_TYPE_WASHER, THING_TYPE_DRYER,
-                    THING_TYPE_FRIDGE_FREEZER, THING_TYPE_COFFEE_MAKER)
+                    THING_TYPE_FRIDGE_FREEZER, THING_TYPE_COFFEE_MAKER, THING_TYPE_HOB)
             .collect(Collectors.toSet());
 
     // Discoverable devices
     public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_THING_TYPES_UIDS = Stream.of(THING_TYPE_DISHWASHER,
-            THING_TYPE_OVEN, THING_TYPE_WASHER, THING_TYPE_DRYER, THING_TYPE_FRIDGE_FREEZER, THING_TYPE_COFFEE_MAKER)
+            THING_TYPE_OVEN, THING_TYPE_WASHER, THING_TYPE_DRYER, THING_TYPE_FRIDGE_FREEZER, THING_TYPE_COFFEE_MAKER,
+            THING_TYPE_HOB)
             .collect(Collectors.toSet());
 
     // List of state values

--- a/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
@@ -75,7 +75,8 @@ public class HomeConnectDiscoveryService extends AbstractDiscoveryService {
                                 || THING_TYPE_WASHER.getId().equalsIgnoreCase(appliance.getType())
                                 || THING_TYPE_DRYER.getId().equalsIgnoreCase(appliance.getType())
                                 || THING_TYPE_COFFEE_MAKER.getId().equalsIgnoreCase(appliance.getType())
-                                || THING_TYPE_FRIDGE_FREEZER.getId().equalsIgnoreCase(appliance.getType())) {
+                                || THING_TYPE_FRIDGE_FREEZER.getId().equalsIgnoreCase(appliance.getType())
+                                || THING_TYPE_HOB.getId().equalsIgnoreCase(appliance.getType())) {
                             logger.info("[{}] Found {}.", appliance.getHaId(), appliance.getType().toUpperCase());
                             bridgeHandler.getThing().getThings().forEach(thing -> thing.getProperties().get(HA_ID));
 
@@ -95,6 +96,8 @@ public class HomeConnectDiscoveryService extends AbstractDiscoveryService {
                                 thingTypeUID = THING_TYPE_DRYER;
                             } else if (THING_TYPE_COFFEE_MAKER.getId().equalsIgnoreCase(appliance.getType())) {
                                 thingTypeUID = THING_TYPE_COFFEE_MAKER;
+                            } else if (THING_TYPE_HOB.getId().equalsIgnoreCase(appliance.getType())) {
+                                thingTypeUID = THING_TYPE_HOB;
                             } else {
                                 thingTypeUID = THING_TYPE_WASHER;
                             }

--- a/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/factory/HomeConnectHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/factory/HomeConnectHandlerFactory.java
@@ -30,6 +30,7 @@ import org.openhab.binding.homeconnect.internal.handler.HomeConnectCoffeeMakerHa
 import org.openhab.binding.homeconnect.internal.handler.HomeConnectDishwasherHandler;
 import org.openhab.binding.homeconnect.internal.handler.HomeConnectDryerHandler;
 import org.openhab.binding.homeconnect.internal.handler.HomeConnectFridgeFreezerHandler;
+import org.openhab.binding.homeconnect.internal.handler.HomeConnectHobHandler;
 import org.openhab.binding.homeconnect.internal.handler.HomeConnectOvenHandler;
 import org.openhab.binding.homeconnect.internal.handler.HomeConnectWasherHandler;
 import org.osgi.framework.ServiceRegistration;
@@ -77,6 +78,8 @@ public class HomeConnectHandlerFactory extends BaseThingHandlerFactory {
             return new HomeConnectFridgeFreezerHandler(thing);
         } else if (THING_TYPE_COFFEE_MAKER.equals(thingTypeUID)) {
             return new HomeConnectCoffeeMakerHandler(thing);
+        }  else if (THING_TYPE_HOB.equals(thingTypeUID)) {
+            return new HomeConnectHobHandler(thing);
         }
 
         return null;

--- a/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectHobHandler.java
+++ b/addons/binding/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectHobHandler.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.homeconnect.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.homeconnect.internal.client.model.Option;
+import org.openhab.binding.homeconnect.internal.client.model.Program;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+import static org.eclipse.smarthome.core.library.unit.SmartHomeUnits.PERCENT;
+import static org.eclipse.smarthome.core.library.unit.SmartHomeUnits.SECOND;
+import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.*;
+
+/**
+ * The {@link HomeConnectHobHandler} is responsible for handling commands, which are
+ * sent to one of the channels of a hob.
+ *
+ * @author Nigel Magnay - Initial contribution
+ */
+@NonNullByDefault
+public class HomeConnectHobHandler extends AbstractHomeConnectThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(HomeConnectHobHandler.class);
+
+    public HomeConnectHobHandler(Thing thing) {
+        super(thing);
+
+        // register default SSE event handlers
+
+        registerEventHandler(EVENT_OPERATION_STATE, defaultOperationStateEventHandler());
+        registerEventHandler(EVENT_REMOTE_CONTROL_ACTIVE,
+                defaultBooleanEventHandler(CHANNEL_REMOTE_CONTROL_ACTIVE_STATE));
+        registerEventHandler(EVENT_LOCAL_CONTROL_ACTIVE,
+                defaultBooleanEventHandler(CHANNEL_LOCAL_CONTROL_ACTIVE_STATE));
+
+
+        registerEventHandler(EVENT_SELECTED_PROGRAM, defaultSelectedProgramStateEventHandler());
+
+        registerEventHandler(EVENT_PROGRAM_FINISHED, event -> {
+
+        });
+
+        registerEventHandler(EVENT_ALARM_ELAPSED, event -> {
+
+        });
+
+        registerEventHandler(EVENT_PREHEAT_FINISHED, event -> {
+
+        });
+
+
+        registerEventHandler(EVENT_POWER_STATE, event -> {
+            getThingChannel(CHANNEL_POWER_STATE).ifPresent(channel -> updateState(channel.getUID(),
+                    STATE_POWER_ON.equals(event.getValue()) ? OnOffType.ON : OnOffType.OFF));
+
+            if (STATE_POWER_ON.equals(event.getValue())) {
+                // revert active program states
+                resetProgramStateChannels();
+
+                // refresh all channels
+                updateChannels();
+            } else {
+                resetAllChannels();
+            }
+
+        });
+        registerEventHandler(EVENT_ACTIVE_PROGRAM, event -> {
+            getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(channel -> {
+                updateState(channel.getUID(),
+                        event.getValue() == null ? UnDefType.NULL : new StringType(mapStringType(event.getValue())));
+
+                // revert other channels
+                if (event.getValue() == null) {
+                    resetProgramStateChannels();
+                }
+            });
+        });
+
+
+        // register default update handlers
+
+        registerChannelUpdateHandler(CHANNEL_POWER_STATE, defaultPowerStateChannelUpdateHandler());
+        registerChannelUpdateHandler(CHANNEL_OPERATION_STATE, defaultOperationStateChannelUpdateHandler());
+        registerChannelUpdateHandler(CHANNEL_REMOTE_CONTROL_ACTIVE_STATE,
+                defaultRemoteControlActiveStateChannelUpdateHandler());
+        registerChannelUpdateHandler(CHANNEL_REMOTE_START_ALLOWANCE_STATE,
+                defaultRemoteStartAllowanceChannelUpdateHandler());
+        registerChannelUpdateHandler(CHANNEL_SELECTED_PROGRAM_STATE, defaultSelectedProgramStateUpdateHandler());
+
+        // register oven specific update handlers
+        registerChannelUpdateHandler(CHANNEL_ACTIVE_PROGRAM_STATE, (channelUID, client) -> {
+            Program program = client.getActiveProgram(getThingHaId());
+            if (program != null && program.getKey() != null) {
+                updateState(channelUID, new StringType(mapStringType(program.getKey())));
+                program.getOptions().forEach(option -> {
+                    switch (option.getKey()) {
+                        case OPTION_REMAINING_PROGRAM_TIME:
+                            getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE)
+                                    .ifPresent(channel -> updateState(channel.getUID(),
+                                            option.getValueAsInt() == 0 ? UnDefType.NULL
+                                                    : new QuantityType<>(option.getValueAsInt(), SECOND)));
+                            break;
+                        case OPTION_PROGRAM_PROGRESS:
+                            getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
+                                    .ifPresent(channel -> updateState(channel.getUID(),
+                                            option.getValueAsInt() == 100 ? UnDefType.NULL
+                                                    : new QuantityType<>(option.getValueAsInt(), PERCENT)));
+                            break;
+                        case OPTION_ELAPSED_PROGRAM_TIME:
+                            getThingChannel(CHANNEL_ELAPSED_PROGRAM_TIME)
+                                    .ifPresent(channel -> updateState(channel.getUID(),
+                                            new QuantityType<>(option.getValueAsInt(), SECOND)));
+                            break;
+                    }
+                });
+            } else {
+                updateState(channelUID, UnDefType.NULL);
+                resetProgramStateChannels();
+            }
+        });
+       
+    }
+
+    @Override
+    public String toString() {
+        return "HomeConnectHobHandler [haId: " + getThingHaId() + "]";
+    }
+
+    private void resetProgramStateChannels() {
+        logger.debug("Resetting active program channel states");
+        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.NULL));
+        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.NULL));
+        getThingChannel(CHANNEL_ELAPSED_PROGRAM_TIME).ifPresent(c -> updateState(c.getUID(), UnDefType.NULL));
+    }
+
+    private void resetAllChannels() {
+        logger.debug("Resetting all channels");
+        getThing().getChannels().forEach(channel -> {
+            if (!CHANNEL_POWER_STATE.equals(channel.getUID().getId())) {
+                updateState(channel.getUID(), UnDefType.NULL);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Hey - thanks for the homeconnect binding - I've added the hob type (tested in my local environment and is ok). There's 3 further events that I register for (based on the Home API documentation) but don't map to a channel, those could either be removed or bound to something if they end up being useful..


Signed-off-by: Nigel Magnay <nigel.magnay@gmail.com>
